### PR TITLE
Feature: append HTML classes to a category section via html_class option

### DIFF
--- a/lib/cheatset/dsl/category.rb
+++ b/lib/cheatset/dsl/category.rb
@@ -2,7 +2,7 @@ module Cheatset
   module DSL
     class Category < Base
       attr_reader :entries
-      define_attrs :id, :hasEntry
+      define_attrs :id, :hasEntry, :html_class
       define_list_attrs :header
 
       def initialize(&block)

--- a/lib/cheatset/templates/template.haml
+++ b/lib/cheatset/templates/template.haml
@@ -24,7 +24,7 @@
       %p~ introduction
 
       - categories.each do |category|
-        %section.category
+        %section.category{class: category.html_class}
           - if !category.hasEntry
             %a{name: "//dash_ref/Entry/#{category.id.strip.gsub(/\//, '%2F')}/0"}
           %h2{id:"//dash_ref/Category/#{category.id.strip.gsub(/\//, '%2F')}/1"}


### PR DESCRIPTION
I'd like to qualify tables in `<section>` tags of categories, so I added a new method to do this.

Usage:

``` rb
category do
  id "Local Variables"
  html_class "simple-listing"
end
```

Result:

``` html
<section class="category simple-listing">
<!-- ... -->
</section>
```

---

I added this feature for my own cheat sheet, so that I can apply different styles on some categories: chitsaou/font-awesome-cheatsheet@793b3808e8cb5e27c790d2c8c5b1fd66ae89a718
