### PR TITLE
Let `resources` accept absolute path.

### DIFF
--- a/lib/cheatset/creator.rb
+++ b/lib/cheatset/creator.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'haml'
 require 'ostruct'
 require 'uri'
+require 'pathname'
 
 class Cheatset::Creator
   def initialize(cheatsheet, filename)
@@ -43,8 +44,13 @@ class Cheatset::Creator
     FileUtils.cp_r("#{tpl_path}/cheatset_resources", doc_path)
     resources = @cheatsheet.resources
     if resources && !resources.empty?
-      base_dir = File.dirname(@filename)
-      resources_path = "#{base_dir}/#{resources}"
+      if Pathname.new(resources).absolute?
+        resources_path = resources
+      else
+        base_dir = File.dirname(@filename)
+        resources_path = "#{base_dir}/#{resources}"
+      end
+
       FileUtils.cp_r(resources_path, doc_path)
     end
   end


### PR DESCRIPTION
As mentioned in Kapeli/cheatsheets#31, I'd like to specify an absolute path for `resources` method but was not possible. This patch makes it possible to assign absolute path for `resources`.

Example (assume that Kapeli/cheatsheets repository is checked out in `projects/cheatsheets` dir):

``` rb
# projects/cheatsheets/cheatsheets/My_Cheatsheet.rb
RES_DIR = `File.expand_path(__FILE__, "../resources/My_Cheatsheet/")`.
resources RES_DIR #=> resolves to /path/to/projects/cheatsheets/resources/My_Cheatsheet/"
```

If a non-absolute path is passed in, it will resolve relative path. For example:

``` rb
# projects/cheatsheets/cheatsheets/My_Cheatsheet.rb
resources "assets" #=> resolves to '/path/to/projects/cheatsheets/cheatsheets/assets/'
```
