### PR TITLE
when evaluating a cheatsheet ruby script, let it know where __FILE__ is.

### DIFF
--- a/lib/cheatset/dsl/context.rb
+++ b/lib/cheatset/dsl/context.rb
@@ -2,7 +2,7 @@ module Cheatset
   module DSL
     class Context
       def initialize(filename)
-        instance_eval(File.read(filename))
+        instance_eval(File.read(filename), File.expand_path(filename))
         @filename = filename
       end
       def generate


### PR DESCRIPTION
No more workarounds mentioned in Kapeli/cheatsheets#31.

Now when generating cheatsheet via `cheatset` command, in the cheatsheet Ruby script, we can reference the current cheatsheet ruby file via `__FILE__`.

See example at chitsaou/cheatsheets@ddf603d601c6b7b90abc1da98d71815117851e11.
