### PR TITLE
Addressing "dead" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following values may contain Markdown or HTML:
 * The `introduction` and the `notes` of the cheat sheet
 * The `name` and the `notes` of the entries
 
-Syntax highlighting is supported (see Ruby code in the sample). For a list of supported languages, see [Rouge's Demo Page](http://rouge.jayferd.us/demo)
+Syntax highlighting is supported (see Ruby code in the sample). For a list of supported languages, see the [rouge](http://rouge.jneen.net/) [lexer repository](https://github.com/jneen/rouge/tree/master/spec/lexers)
 
 For more complete examples look at some of
 [the actual cheat sheets](https://github.com/Kapeli/cheatsheets/tree/master/cheatsheets).


### PR DESCRIPTION
The rouge demo page link is “dead”. My suggestion is linking to the lexer directory of the rouge repository, since this is a moving target and this directory seems to be the only available listing. The rouge website just lists a number so no exact list of supported languages seems available.

Also added a link to the rouge website.