### PR TITLE
Restore bin/cheatset

### DIFF
--- a/bin/cheatset
+++ b/bin/cheatset
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path('../../lib', __FILE__)
+require 'cheatset'
+require 'cheatset/cli'
+Cheatset::CLI.start


### PR DESCRIPTION
It looks like bin/cheatset was removed in commit 1741acf7d9344323b1eb491ed175e9a091171211, but I can't see a reason why it was.
As the gem currently stands, there is no way to generate a cheatsheet for Dash.