### PR TITLE
If a section does not fit on a print page move it to next section

### DIFF
--- a/lib/cheatset/templates/style.css
+++ b/lib/cheatset/templates/style.css
@@ -92,6 +92,13 @@ section.notes {
 article {
   margin: 2em 1em; }
 
+@media print {
+    section.category {
+        page-break-inside: avoid;
+        break-inside: avoid;
+    }
+}
+
 section.category {
   border: 2px solid #666;
   border-radius: 6px 6px;

--- a/lib/cheatset/templates/style.scss
+++ b/lib/cheatset/templates/style.scss
@@ -69,7 +69,7 @@ code, pre {
   font-size:13px;
 }
 
-code {  
+code {
   margin:0;
   border:1px solid #ddd;
   background-color:#f8f8f8;
@@ -119,6 +119,14 @@ section.notes {
 article {
   margin: 2em 1em;
 }
+
+@media print {
+  section.category {
+      page-break-inside: avoid;
+      break-inside: avoid;
+  }
+}
+
 section.category {
   border: 2px solid $dark_gray;
   border-radius: 6px 6px;
@@ -145,7 +153,7 @@ td {
 }
 th {
   border-left:1px solid $lighter_gray;
-}  
+}
 tr {
   border-bottom:1px dotted $lighter_gray;
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/break-inside

the scss was not auto generated so I added manually, may need modification.

I used this for the following cheatsheet:
https://github.com/Kapeli/cheatsheets/blob/master/cheatsheets/tmux.rb

## Old
<img width="598" alt="Screen Shot 2021-12-28 at 10 12 19 AM" src="https://user-images.githubusercontent.com/11463275/147580253-c4a0275a-b95f-4805-874f-12726664d4ad.png">

## New
<img width="998" alt="Screen Shot 2021-12-28 at 10 14 03 AM" src="https://user-images.githubusercontent.com/11463275/147580402-a7f7cc6f-2cea-4135-95ba-1ce6b90b8331.png">
