### PR TITLE
Fixed typo for docker image pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you do not use Ruby or lack a working Ruby toolchain and still want to genera
 
 You can use the `cheatset` Docker image.
 
-    $ docker pull jonasbn/cheatset:lastest
+    $ docker pull jonasbn/cheatset:latest
     $ docker run --rm  -it --volume $PWD:/tmp --name cheatset jonasbn/cheatset:latest generate samble.rb
 
 For more details on the Docker image please visit the repositories on [DockerHub](https://hub.docker.com/repository/docker/jonasbn/cheatset) or [GitHub](https://github.com/jonasbn/docker-cheatset)


### PR DESCRIPTION
Fixed a typo in the docs for pulling the docker image:

```
docker pull jonasbn/cheatset:latest
latest: Pulling from jonasbn/cheatset
Digest: sha256:2bea026ce8b9b305421a30c019b8df2df3feaca765c9df820dd47ec8b5146d36
Status: Image is up to date for jonasbn/cheatset:latest
docker.io/jonasbn/cheatset:latest
```