### PR TITLE
Fix HAML rendering issue

### DIFF
--- a/lib/cheatset/creator.rb
+++ b/lib/cheatset/creator.rb
@@ -31,7 +31,7 @@ class Cheatset::Creator
   def generate_html_file
     # HTML
     template = File.read("#{tpl_path}/template.haml")
-    engine = Haml::Engine.new(template)
+    engine = Haml::Template.new { template }
     out = engine.render(@cheatsheet)
     doc_path = "#{@path}Resources/Documents/"
     FileUtils.mkdir_p(doc_path)


### PR DESCRIPTION
This PR updates the `lib/cheatset/creator.rb` component to call `Haml::Template` instead of `Haml::Engine` (per https://github.com/haml/haml/commit/519ef23b55cc5f8b29ecc9849006f272b3d78802)

Resolves issue https://github.com/Kapeli/cheatset/issues/40